### PR TITLE
Add external_file_field functionality to query

### DIFF
--- a/sunspot/lib/sunspot/field_factory.rb
+++ b/sunspot/lib/sunspot/field_factory.rb
@@ -36,7 +36,9 @@ module Sunspot
           raise ArgumentError, "Invalid field name #{name}: only letters, numbers, and underscores are allowed."
         end
         @field =
-          if type.is_a?(Type::TextType)
+          if options[:external_file] == true
+            ExternalFileField.new(name, type, options)
+          elsif type.is_a?(Type::TextType)
             FulltextField.new(name, options)
           else
             AttributeField.new(name, type, options)

--- a/sunspot/lib/sunspot/query.rb
+++ b/sunspot/lib/sunspot/query.rb
@@ -1,5 +1,5 @@
 %w(filter abstract_field_facet connective boost_query date_field_facet range_facet dismax
-   field_facet highlighting pagination restriction common_query
+   field_facet highlighting pagination restriction external_file_restriction common_query
    standard_query more_like_this more_like_this_query geo geofilt bbox query_facet
    scope sort sort_composite text_field_boost function_query field_stats
    composite_fulltext field_group).each do |file|

--- a/sunspot/lib/sunspot/query/connective.rb
+++ b/sunspot/lib/sunspot/query/connective.rb
@@ -16,7 +16,7 @@ module Sunspot
         # Add a restriction to the connective.
         #
         def add_restriction(negated, field, restriction_type, *value)
-          add_component(restriction_type.new(negated, field, *value))
+          add_component(restriction_type.build(negated, field, *value))
         end
 
         # 

--- a/sunspot/lib/sunspot/query/external_file_restriction.rb
+++ b/sunspot/lib/sunspot/query/external_file_restriction.rb
@@ -1,0 +1,114 @@
+module Sunspot
+  module Query
+    module ExternalFileRestriction #:nodoc:
+
+      class Base < Sunspot::Query::Restriction::Base
+        #
+        # Boolean phrase representing this restriction in the positive. Subclasses
+        # may choose to implement this method rather than #to_params; however,
+        # this method delegates to the abstract #to_solr_conditional method, which
+        # in most cases will be what subclasses will want to implement.
+        # #to_solr_conditional contains the boolean phrase representing the
+        # condition but leaves out the field name (see built-in implementations
+        # for examples)
+        #
+        # ==== Returns
+        #
+        # String:: Boolean phrase for restriction in the positive
+        #
+        def to_positive_boolean_phrase
+          "#{to_solr_conditional}#{escape(@field.indexed_name)}"
+        end
+
+        #
+        # Boolean phrase representing this restriction in the negated. Subclasses
+        # may choose to implement this method, but it is not necessary, as the
+        # base implementation delegates to #to_positive_boolean_phrase.
+        #
+        # ==== Returns
+        #
+        # String:: Boolean phrase for restriction in the negated
+        #
+        def to_negated_boolean_phrase
+          "-#{to_positive_boolean_phrase}"
+        end
+
+        def solr_value(value = @value)
+          @field.to_indexed(value)
+        end
+      end
+
+      #
+      # Results must have field with value equal to given value. If the value
+      # is nil, results must have no value for the given field.
+      #
+      class EqualTo < Base
+        private
+
+        def to_solr_conditional
+          "{!frange l=#{solr_value} u=#{solr_value}}"
+        end
+      end
+
+      #
+      # Results must have field with value less than given value
+      #
+      class LessThan < Base
+        private
+
+        def to_solr_conditional
+          "{!frange u=#{solr_value} incu=false}"
+        end
+      end
+
+      #
+      # Results must have field with value less or equal to than given value
+      #
+      class LessThanOrEqualTo < Base
+        private
+
+        def to_solr_conditional
+          "{!frange u=#{solr_value} incu=true}"
+        end
+      end
+
+      #
+      # Results must have field with value greater than given value
+      #
+      class GreaterThan < Base
+        private
+
+        def to_solr_conditional
+          "{!frange l=#{solr_value} incl=false}"
+        end
+      end
+
+      #
+      # Results must have field with value greater than or equal to given value
+      #
+      class GreaterThanOrEqualTo < Base
+        private
+
+        def to_solr_conditional
+          "{!frange l=#{solr_value} incl=true}"
+        end
+      end
+
+      #
+      # Results must have field with value in given range
+      #
+      class Between < Base
+        private
+
+        def to_solr_conditional
+          "{!frange l=#{solr_value.first} u=#{solr_value.last} incl=true incu=true}"
+        end
+
+        def solr_value(value = @value)
+          [@field.to_indexed(value.first), @field.to_indexed(value.last)]
+        end
+      end
+
+    end
+  end
+end

--- a/sunspot/lib/sunspot/query/restriction.rb
+++ b/sunspot/lib/sunspot/query/restriction.rb
@@ -47,7 +47,20 @@ module Sunspot
           @negated, @field, @value = negated, field, value
         end
 
-        # 
+        #
+        # A factory method for creating an instance of a particular Restriction.
+        # This allows FieldType specific restrictions to be used when necessary.
+        #
+        def self.build(negated, field, value)
+          if field.external_file_field?
+            restriction_class_name = self.name.gsub('::Restriction::', '::ExternalFileRestriction::')
+            const_get(restriction_class_name).new(negated, field, value)
+          else
+            self.new(negated, field, value)
+          end
+        end
+
+        #
         # A hash representing this restriction in solr-ruby's parameter format.
         # All restriction implementations must respond to this method; however,
         # the base implementation delegates to the #to_positive_boolean_phrase method, so

--- a/sunspot/lib/sunspot/query/sort.rb
+++ b/sunspot/lib/sunspot/query/sort.rb
@@ -67,7 +67,11 @@ module Sunspot
         end
 
         def to_param
-          "#{@field.indexed_name.to_sym} #{direction_for_solr}"
+          if @field.external_file_field?
+            "field(#{@field.indexed_name.to_sym}) #{direction_for_solr}"
+          else
+            "#{@field.indexed_name.to_sym} #{direction_for_solr}"
+          end
         end
       end
 

--- a/sunspot/spec/api/query/external_file_restriction_spec.rb
+++ b/sunspot/spec/api/query/external_file_restriction_spec.rb
@@ -1,0 +1,51 @@
+require File.expand_path('spec_helper', File.dirname(__FILE__))
+
+describe 'external file field' do
+  it 'can search by external file field with value' do
+    session.search Photo do
+      with(:popularity, '2')
+    end
+    connection.should have_last_search_including(
+      :fq, "{!frange l=2.0 u=2.0}popularity_ext")
+  end
+
+  it 'can search by external file field with greater_than value' do
+    session.search Photo do
+      with(:popularity).greater_than('1')
+    end
+    connection.should have_last_search_including(
+      :fq, "{!frange l=1.0 incl=false}popularity_ext")
+  end
+
+  it 'can search by external file field with less_than value' do
+    session.search Photo do
+      with(:popularity).less_than('5')
+    end
+    connection.should have_last_search_including(
+      :fq, "{!frange u=5.0 incu=false}popularity_ext")
+  end
+
+  it 'can search by external file field with greater_than_or_equal_to value' do
+    session.search Photo do
+      with(:popularity).greater_than_or_equal_to('1')
+    end
+    connection.should have_last_search_including(
+      :fq, "{!frange l=1.0 incl=true}popularity_ext")
+  end
+
+  it 'can search by external file field with less_than_or_equal_to value' do
+    session.search Photo do
+      with(:popularity).less_than_or_equal_to('5')
+    end
+    connection.should have_last_search_including(
+      :fq, "{!frange u=5.0 incu=true}popularity_ext")
+  end
+
+  it 'can search by external file field with between value' do
+    session.search Photo do
+      with(:popularity, 2.0..5.0)
+    end
+    connection.should have_last_search_including(
+      :fq, "{!frange l=2.0 u=5.0 incl=true incu=true}popularity_ext")
+  end
+end

--- a/sunspot/spec/mocks/photo.rb
+++ b/sunspot/spec/mocks/photo.rb
@@ -10,6 +10,7 @@ Sunspot.setup(Photo) do
   integer :size, :trie => true
   float :average_rating, :trie => true
   time :created_at, :trie => true
+  float :popularity, :external_file => true
 end
 
 class PhotoContainer < MockRecord

--- a/sunspot_solr/solr/solr/conf/schema.xml
+++ b/sunspot_solr/solr/solr/conf/schema.xml
@@ -88,6 +88,9 @@
 
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
+
+    <!-- A specialized field for ExternalFileFields -->
+    <fieldType name="ext_file_field" keyField="id" class="solr.ExternalFileField" valType="float" />
   </types>
   <fields>
     <!-- Valid attributes for fields:
@@ -236,7 +239,10 @@
     <dynamicField name="*_llm" stored="false" type="location" multiValued="true" indexed="true"/>
     <dynamicField name="*_lls" stored="true" type="location" multiValued="false" indexed="true"/>
     <dynamicField name="*_llms" stored="true" type="location" multiValued="true" indexed="true"/>
-    
+
+    <!-- Dynamic field for use with external_file_fields. -->
+    <dynamicField name="*_ext" type="ext_file_field" />
+
     <!-- required by Solr 4 -->
     <field name="_version_" type="string" indexed="true" stored="true" multiValued="false" />
   </fields>


### PR DESCRIPTION
This adds the ability to filter, sort, and (facet query rows only) with external file fields. All that needs to change in consumption is to use `index.float(:popularity, external_file: true)`
