### PR TITLE
Add .document method to hit

### DIFF
--- a/sunspot/lib/sunspot/field_factory.rb
+++ b/sunspot/lib/sunspot/field_factory.rb
@@ -153,6 +153,20 @@ module Sunspot
         end
       end
 
+      def build_from_indexed_name(indexed_name)
+        if dynamic_root = "#{indexed_name}".gsub!(/^#{name}:/, '')
+          if (field = build(dynamic_root)) && field.indexed_name == indexed_name
+            return field
+          elsif (field = build(dynamic_root.match(/(.*)(_.*)$/)[1])) && field.indexed_name == indexed_name
+            return field
+          end
+        end
+        raise(
+          UnrecognizedFieldError,
+          "#{indexed_name} is not a dynamic field"
+        )
+      end
+
       # 
       # Unique signature identifying this dynamic field based on name and type
       #

--- a/sunspot/lib/sunspot/search/hit.rb
+++ b/sunspot/lib/sunspot/search/hit.rb
@@ -97,6 +97,26 @@ module Sunspot
       end
 
       #
+      # Returns hash of raw solr document with each field transforming
+      # field.indexed_name to field.name and casting value based on
+      # field defintion.
+      #
+      def document
+        @document ||= {}.tap do |doc|
+          @stored_values.each do |key, value|
+            field = (setup.field_from_indexed_name(key) rescue nil)
+            if field
+              doc[field.name.to_s] = Array(value).map { |val|
+                field.cast(val)
+              }.send((field.multiple? ? :to_a: :first))
+            else
+              doc[key] = value
+            end
+          end
+        end
+      end
+
+      #
       # Returns the instance primary key when the Hit is used to generate urls
       # For example, using a search that stores the :name attribute:
       #

--- a/sunspot/lib/sunspot/search/hit_enumerable.rb
+++ b/sunspot/lib/sunspot/search/hit_enumerable.rb
@@ -15,6 +15,16 @@ module Sunspot
         hits.select { |h| h.result }
       end
 
+      #
+      # Return raw solr documents with each field transforming field.indexed_name
+      # to field.name and casting value based on field defintion. See Hit.document
+      #
+      def documents
+        @documents ||= hits.map do |hit|
+          hit.document
+        end
+      end
+
       # 
       # Populate the Hit objects with their instances. This is invoked the first
       # time any hit has its instance requested, and all hits are loaded as a

--- a/sunspot/lib/sunspot/setup.rb
+++ b/sunspot/lib/sunspot/setup.rb
@@ -175,6 +175,23 @@ module Sunspot
       )
     end
 
+    #
+    # Return a Field given an (indexed) name
+    #
+    def field_from_indexed_name(indexed_name)
+      indexed_name = indexed_name.to_s
+      @indexed_fields_by_name ||= {}
+      @indexed_fields_by_name[indexed_name] ||= all_field_factories.find { |factory|
+        if factory.is_a?(FieldFactory::Dynamic)
+          # Returns built field here and stops iteration
+          break (factory.build_from_indexed_name(indexed_name) rescue false)
+        elsif factory.build.indexed_name == indexed_name
+          # Returns built field here and stops iteration
+          break factory.build
+        end
+      }
+    end
+
     # 
     # Return all attribute fields
     #

--- a/sunspot/lib/sunspot/type.rb
+++ b/sunspot/lib/sunspot/type.rb
@@ -81,6 +81,10 @@ module Sunspot
           "#{self.class.name} cannot be used as a Solr literal"
         )
       end
+
+      def cast(value)
+        value
+      end
     end
 
     # 

--- a/sunspot/spec/api/hit_enumerable_spec.rb
+++ b/sunspot/spec/api/hit_enumerable_spec.rb
@@ -44,4 +44,9 @@ describe Sunspot::Search::HitEnumerable do
       subject.populate_hits
     end
   end
+
+  it 'can return a set of documents' do
+    subject.stub(:solr_docs).and_return(nil)
+    subject.documents.should == []
+  end
 end

--- a/sunspot/spec/api/search/hits_spec.rb
+++ b/sunspot/spec/api/search/hits_spec.rb
@@ -144,4 +144,27 @@ describe 'hits', :type => :search do
     stub_full_results('instance' => User.new, 'role_ids_ims' => %w(1 4 5))
     session.search(User).hits.first.stored(:role_ids).should == [1, 4, 5]
   end
+
+  it 'should return a full solr document with fields casted' do
+    time = Time.utc(2008, 7, 8, 2, 45)
+    stub_full_results('instance' => Post.new,
+      'title_ss' => 'Post 1',
+      'featured_bs' => 'true',
+      'last_indexed_at_ds' => time.xmlschema,
+      'body_textsv' => nil,
+      'custom_string:tag1_ss' => 'popular',
+      'score' => 4,
+      'distance' => 3.42,
+    )
+    document = session.search(Post).hits.first.document
+    document.should include(
+      'title' => 'Post 1',
+      'featured' => true,
+      'last_indexed_at' => time,
+      'body_text' => nil,
+      'custom_string:tag1' => 'popular',
+      'score' => 4,
+      'distance' => 3.42,
+    )
+  end
 end


### PR DESCRIPTION
Adds `.document` which takes the raw solr document and transforms keys to non dynamic names and casts values based on sunspot setup definition.
