### PR TITLE
Fix dynamic fields in hit.document

### DIFF
--- a/sunspot/lib/sunspot/field.rb
+++ b/sunspot/lib/sunspot/field.rb
@@ -13,6 +13,8 @@ module Sunspot
       @stored = !!options.delete(:stored)
       @more_like_this = !!options.delete(:more_like_this)
       @multiple ||= false
+      @dynamic_root ||= options.delete(:dynamic_root)
+      @dynamic_name ||= options.delete(:dynamic_name)
       set_indexed_name(options)
       raise ArgumentError, "Field of type #{type} cannot be used for more_like_this" unless type.accepts_more_like_this? or !@more_like_this
     end
@@ -92,6 +94,39 @@ module Sunspot
     #
     def external_file_field?
       !!@external_file_field
+    end
+
+    #
+    # Whether this field is a dynamic field
+    #
+    # ==== Returns
+    #
+    # Boolean:: True if this field is a dynamic field
+    #
+    def dynamic_field?
+      !!(@dynamic_root || @dynamic_name)
+    end
+
+    #
+    # Get the parent dynamic root name (before semicolon)
+    #
+    # ==== Returns
+    #
+    # String:: Dynamic root name
+    #
+    def dynamic_root
+      @dynamic_root
+    end
+
+    #
+    # Get the dynamic name of this field (after semicolon)
+    #
+    # ==== Returns
+    #
+    # String:: Dynamic name of this field
+    #
+    def dynamic_name
+      @dynamic_name
     end
 
     def hash

--- a/sunspot/lib/sunspot/field_factory.rb
+++ b/sunspot/lib/sunspot/field_factory.rb
@@ -127,7 +127,8 @@ module Sunspot
       # Build a field based on the dynamic name given.
       #
       def build(dynamic_name)
-        AttributeField.new("#{@name}:#{dynamic_name}", @type, @options.dup)
+        opts = @options.dup.merge({dynamic_root: @name, dynamic_name: dynamic_name})
+        AttributeField.new("#{@name}:#{dynamic_name}", @type, opts)
       end
       # 
       # This alias allows a DynamicFieldFactory to be used in place of a Setup

--- a/sunspot/lib/sunspot/setup.rb
+++ b/sunspot/lib/sunspot/setup.rb
@@ -183,8 +183,10 @@ module Sunspot
       @indexed_fields_by_name ||= {}
       @indexed_fields_by_name[indexed_name] ||= all_field_factories.find { |factory|
         if factory.is_a?(FieldFactory::Dynamic)
-          # Returns built field here and stops iteration
-          break (factory.build_from_indexed_name(indexed_name) rescue false)
+          if dynamic_field = (factory.build_from_indexed_name(indexed_name) rescue nil)
+            # Returns built field here and stops iteration
+            break dynamic_field
+          end
         elsif factory.build.indexed_name == indexed_name
           # Returns built field here and stops iteration
           break factory.build

--- a/sunspot/spec/api/search/hits_spec.rb
+++ b/sunspot/spec/api/search/hits_spec.rb
@@ -158,13 +158,14 @@ describe 'hits', :type => :search do
     )
     document = session.search(Post).hits.first.document
     document.should include(
-      'title' => 'Post 1',
-      'featured' => true,
-      'last_indexed_at' => time,
-      'body_text' => nil,
-      'custom_string:tag1' => 'popular',
-      'score' => 4,
-      'distance' => 3.42,
+      "title"=>"Post 1",
+      "featured"=>true,
+      "last_indexed_at"=> time,
+      "body"=>[],
+      "custom_string"=>{"tag1"=>"popular"},
+      "score"=>4,
+      "distance"=>3.42,
+      "id"=>"Post 27"
     )
   end
 end


### PR DESCRIPTION
This adds a few methods onto the built `field` to allow us to get the root/suffix parts of the dynamic name (essentially split on `:`, but that didn't seem to safe)
