### PR TITLE
Fix Rails 4.2 deprecation warning.

### DIFF
--- a/sunspot_rails/lib/sunspot_rails.rb
+++ b/sunspot_rails/lib/sunspot_rails.rb
@@ -1,7 +1,7 @@
 # This needs to be loaded before sunspot/search/paginated_collection
 # or #to_json gets defined in Object breaking delegation to Array via
 # method_missing
-require 'active_support/core_ext/object/to_json'
+require 'active_support/core_ext/object/json'
 
 require 'sunspot/rails'
 require 'sunspot/rails/railtie'


### PR DESCRIPTION
Get rid of the annoying deprecation warning:

> DEPRECATION WARNING: You have required `active_support/core_ext/object/to_json`. This file will be removed in Rails 4.2. You should require `active_support/core_ext/object/json` instead. (called from require at /Users/rchurchill/Projects/platform-api-etl/vendor/bundle/bundler/gems/sunspot-17eb825f7291/sunspot_rails/lib/sunspot_rails.rb:4)