### PR TITLE
PUI-4428: Pass on args passed to commit in the session proxy

### DIFF
--- a/sunspot/lib/sunspot/session_proxy/sharding_session_proxy.rb
+++ b/sunspot/lib/sunspot/session_proxy/sharding_session_proxy.rb
@@ -115,8 +115,8 @@ module Sunspot
       # 
       # Commit all shards. See Sunspot.commit
       #
-      def commit
-        all_sessions.each { |session| session.commit }
+      def commit(*args)
+        all_sessions.each { |session| session.commit(*args) }
       end
 
       # 


### PR DESCRIPTION
This allows { soft_commit: true } to be passed through the session proxy.  Was causing an error when I tried making changes to ETL.