### PR TITLE
Remove exception as flow control in dynamic field building

### DIFF
--- a/sunspot/lib/sunspot/field_factory.rb
+++ b/sunspot/lib/sunspot/field_factory.rb
@@ -157,15 +157,11 @@ module Sunspot
       def build_from_indexed_name(indexed_name)
         if dynamic_root = "#{indexed_name}".gsub!(/^#{name}:/, '')
           if (field = build(dynamic_root)) && field.indexed_name == indexed_name
-            return field
+            field
           elsif (field = build(dynamic_root.match(/(.*)(_.*)$/)[1])) && field.indexed_name == indexed_name
-            return field
+            field
           end
         end
-        raise(
-          UnrecognizedFieldError,
-          "#{indexed_name} is not a dynamic field"
-        )
       end
 
       # 

--- a/sunspot/lib/sunspot/search/hit.rb
+++ b/sunspot/lib/sunspot/search/hit.rb
@@ -104,8 +104,7 @@ module Sunspot
       def document
         @document ||= {}.tap do |doc|
           @stored_values.each do |key, value|
-            field = (setup.field_from_indexed_name(key) rescue nil)
-            if field
+            if field = setup.field_from_indexed_name(key)
               if field.dynamic_field?
                 doc[field.dynamic_root.to_s] ||= {}
                 doc[field.dynamic_root.to_s][field.dynamic_name.to_s] =\

--- a/sunspot/lib/sunspot/setup.rb
+++ b/sunspot/lib/sunspot/setup.rb
@@ -181,17 +181,21 @@ module Sunspot
     def field_from_indexed_name(indexed_name)
       indexed_name = indexed_name.to_s
       @indexed_fields_by_name ||= {}
-      @indexed_fields_by_name[indexed_name] ||= all_field_factories.find { |factory|
-        if factory.is_a?(FieldFactory::Dynamic)
-          if dynamic_field = (factory.build_from_indexed_name(indexed_name) rescue nil)
+      if @indexed_fields_by_name.has_key?(indexed_name)
+        @indexed_fields_by_name[indexed_name]
+      else
+        @indexed_fields_by_name[indexed_name] = all_field_factories.find { |factory|
+          if factory.is_a?(FieldFactory::Dynamic)
+            if dynamic_field = factory.build_from_indexed_name(indexed_name)
+              # Returns built field here and stops iteration
+              break dynamic_field
+            end
+          elsif factory.build.indexed_name == indexed_name
             # Returns built field here and stops iteration
-            break dynamic_field
+            break factory.build
           end
-        elsif factory.build.indexed_name == indexed_name
-          # Returns built field here and stops iteration
-          break factory.build
-        end
-      }
+        }
+      end
     end
 
     # 

--- a/sunspot/spec/api/search/hits_spec.rb
+++ b/sunspot/spec/api/search/hits_spec.rb
@@ -147,7 +147,8 @@ describe 'hits', :type => :search do
 
   it 'should return a full solr document with fields casted' do
     time = Time.utc(2008, 7, 8, 2, 45)
-    stub_full_results('instance' => Post.new,
+    post = Post.new
+    stub_full_results('instance' => post,
       'title_ss' => 'Post 1',
       'featured_bs' => 'true',
       'last_indexed_at_ds' => time.xmlschema,
@@ -165,7 +166,7 @@ describe 'hits', :type => :search do
       "custom_string"=>{"tag1"=>"popular"},
       "score"=>4,
       "distance"=>3.42,
-      "id"=>"Post 27"
+      "id"=>"Post #{post.id}"
     )
   end
 end


### PR DESCRIPTION
A lot of sunspot field look up methods [use exceptions as flow control](https://github.com/mdx-dev/sunspot/blob/733743abf877b79dc4c4fed56d8ced5fdf42ff17/sunspot/lib/sunspot/setup.rb#L111-L142). In our custom additions to the dynamic field building, I followed that same pattern. However, that has some big performance issues during our building up a document hash from stored values.

In addition, that was exacerbated by the `field_from_indexed_name` method below only caching the result when the field was defined. However, the fields `id` and `score` are not defined sunspot fields so it was essentially calling that method for every document in the response (which for every dynamic field factory was throwing exceptions as flow control). The first request was even worse because it was having to do this for all the fields in a document. 

This fixes those issues, but keeps the external behavior the same. This only changes the custom code we wrote, nothing from sunspot proper. All in all, some big improvements in the app.
**BEFORE**
```
Object alloc
TOTAL    (pct)     SAMPLES    (pct)     FRAME
3509975  (84.5%)      764047  (18.4%)     Sunspot::FieldFactory::Dynamic#build_from_indexed_name
2761959  (66.5%)       29275   (0.7%)     block in <class:Exception>
3719927  (89.5%)        3888   (0.1%)     Sunspot::Setup#field_from_indexed_name

Wall time
TOTAL    (pct)     SAMPLES    (pct)     FRAME
2698  (64.8%)         601  (14.4%)     block in <class:Exception>
2160  (51.9%)          87   (2.1%)     Sunspot::FieldFactory::Dynamic#build_from_indexed_name
2219  (53.3%)          46   (1.1%)     block in Sunspot::Setup#field_from_indexed_name
```

**AFTER**
```
Object alloc
TOTAL    (pct)     SAMPLES    (pct)     FRAME
12574   (2.3%)         145   (0.0%)     block in <class:Exception>
237   (0.0%)         237   (0.0%)     Sunspot::FieldFactory::Dynamic#build_from_indexed_name
355   (0.1%)          49   (0.0%)     block in Sunspot::Setup#field_from_indexed_name

Wall time
TOTAL    (pct)     SAMPLES    (pct)     FRAME
18   (3.2%)           7   (1.2%)     Sunspot::Setup#field_from_indexed_name
41   (7.3%)           9   (1.6%)     block in <class:Exception>
```