### PR TITLE
Update version to 2.5.1 (dependent gems rely on versions higher than 2.1.0)

### DIFF
--- a/sunspot/lib/sunspot/version.rb
+++ b/sunspot/lib/sunspot/version.rb
@@ -1,3 +1,3 @@
 module Sunspot
-  VERSION = '2.1.0'
+  VERSION = '2.5.0'
 end

--- a/sunspot/sunspot.gemspec
+++ b/sunspot/sunspot.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |s|
     can be performed without hand-writing any boolean queries or building Solr parameters by hand.
   TEXT
 
-  s.rubyforge_project = "sunspot"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/sunspot_rails/sunspot_rails.gemspec
+++ b/sunspot_rails/sunspot_rails.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |s|
     Rails request.
   TEXT
 
-  s.rubyforge_project = "sunspot"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/sunspot_solr/sunspot_solr.gemspec
+++ b/sunspot_solr/sunspot_solr.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |s|
     distribution is well suited to development and testing.
   TEXT
 
-  s.rubyforge_project = "sunspot"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
This PR includes two cherry-picks from the non-forked version
- Remove a defunct property referring to the rubyforge_project. Not including this commit should not break anything, but you can fairly argue that including it is unnecessary.
- Bumps up gem version to 2.5.0. This one is necessary. Cucumber 4 had some breaking updates with the tagging system. 
i.e
```
Deprecated: Found tags option '~@wip'. Support for '~@tag' will be removed
from the next release of Cucumber. Please use 'not @tag' instead.
```
The sunspot_test gem recently accommodated their use of tagging with [this change](https://github.com/collectiveidea/sunspot_test/commit/82eeafe3160057b17b00c41e31ce9e4d849a2ef5) as of `0.4.2`

In order to bump up our `sunspot_test` from `0.4.0` to `0.4.2`, to leverage the updated tagging notation, we also have to bump up the version on sunspot (since `0.4.2` depends on a sunspot version greater than `2.1.0`). Unfortunately, we're using this good ol forked version, hence this cherry-pick. Without this update, we can't run our cuke suite. 