### PR TITLE
chore(PUI-20700): Update YAML loading for Ruby 3 compatibility

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -357,7 +357,11 @@ module Sunspot #:nodoc:
             if File.exist?(path)
               File.open(path) do |file|
                 processed = ERB.new(file.read).result
-                YAML.load(processed, aliases: true)[::Rails.env]
+                begin
+                  YAML.load(processed, aliases: true)[::Rails.env]
+                rescue ArgumentError
+                  YAML.load(processed)[::Rails.env]
+                end
               end
             else
               {}

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -357,7 +357,7 @@ module Sunspot #:nodoc:
             if File.exist?(path)
               File.open(path) do |file|
                 processed = ERB.new(file.read).result
-                YAML.load(processed)[::Rails.env]
+                YAML.load(processed, aliases: true)[::Rails.env]
               end
             else
               {}


### PR DESCRIPTION
[PUI-20700](https://sapphire-digital.atlassian.net/browse/PUI-20700)

**Problem**
Ruby 3 uses Psych 4, which requires aliases to be explicitly set via an `aliases` kwarg when loading YAML. Previous versions of Ruby use Psych 3, which do not accept that argument.

Upgrading to Ruby 3 thus leads to this error splatted everywhere:
```
Psych::BadAlias:
  Unknown alias: development_solr
```

[For funsies, check out the original PR in Ruby](https://github.com/ruby/psych/pull/487), and also the [Rails patch](https://github.com/rails/rails/pull/42249).

**Solution**
Update the YAML load with `aliases`.

🪲 🐶 

[PUI-20700]: https://sapphire-digital.atlassian.net/browse/PUI-20700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ