### PR TITLE
revert: chore(PDE-9974): Rails upgrade to 7.2

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
+++ b/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
@@ -33,15 +33,15 @@ module Sunspot
         name = '%s (%.1fms)' % ["SOLR Request", event.duration]
 
         # produces: path=select parameters={fq: ["type:Tag"], q: "rossi", fl: "* score", qf: "tag_name_text", defType: "edismax", start: 0, rows: 20}
-        path = color(event.payload[:path], bold: true)
+        path = color(event.payload[:path], BOLD, true)
         parameters = event.payload[:parameters].map { |k, v|
           v = "\"#{v}\"" if v.is_a? String
           v = v.to_s.gsub(/\\/,'') # unescape
-          "#{k}: #{color(v, bold: true)}"
+          "#{k}: #{color(v, BOLD, true)}"
         }.join(', ')
         request = "path=#{path} parameters={#{parameters}}"
 
-        debug "  #{color(name, GREEN, bold: true)}  [ #{request} ]"
+        debug "  #{color(name, GREEN, true)}  [ #{request} ]"
       end
     end
   end


### PR DESCRIPTION
Reverts mdx-dev/sunspot#27

When authenticating, there is seemingly an error that the sso is not being passed in the cookie. Rails 7 has changed the way it handles that - will look into this while not merged to get a better understanding and not interfere with other peoples work