### PR TITLE
chore(PDE-9974): Rails upgrade to 7.2 attempt #2

### DIFF
--- a/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
+++ b/sunspot_rails/lib/sunspot/rails/log_subscriber.rb
@@ -33,15 +33,15 @@ module Sunspot
         name = '%s (%.1fms)' % ["SOLR Request", event.duration]
 
         # produces: path=select parameters={fq: ["type:Tag"], q: "rossi", fl: "* score", qf: "tag_name_text", defType: "edismax", start: 0, rows: 20}
-        path = color(event.payload[:path], BOLD, true)
+        path = color(event.payload[:path], bold: true)
         parameters = event.payload[:parameters].map { |k, v|
           v = "\"#{v}\"" if v.is_a? String
           v = v.to_s.gsub(/\\/,'') # unescape
-          "#{k}: #{color(v, BOLD, true)}"
+          "#{k}: #{color(v, bold: true)}"
         }.join(', ')
         request = "path=#{path} parameters={#{parameters}}"
 
-        debug "  #{color(name, GREEN, true)}  [ #{request} ]"
+        debug "  #{color(name, GREEN, bold: true)}  [ #{request} ]"
       end
     end
   end


### PR DESCRIPTION
This PR updates the MDX branch of sunspot
[PDE-9974](https://onezelis.atlassian.net/browse/PDE-9974)
> just like PR #27 which was reverted in #28

*Problem*
- `uninitialized constant Sunspot::Rails::LogSubscriber::BOLD` coming up in other repos using this one
- the argument structure has been deprecated in Rails 7.2

*Solution*
- update the file to fit the argument structure of Rails 7.2

[PDE-9974]: https://onezelis.atlassian.net/browse/PDE-9974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ