### PR TITLE
feat(PDE-13822): Ruby upgrade to 3.4.1 attempt

### DIFF
--- a/sunspot_solr/lib/sunspot/solr/server.rb
+++ b/sunspot_solr/lib/sunspot/solr/server.rb
@@ -174,7 +174,7 @@ module Sunspot
       # Boolean:: success
       #
       def install_solr_home
-        unless File.exists?(solr_home)
+        unless File.exist?(solr_home)
           Sunspot::Solr::Installer.execute(
             solr_home,
             :force => true,
@@ -192,7 +192,7 @@ module Sunspot
       #
       def create_solr_directories
         [solr_data_dir, pid_dir].each do |path|
-          FileUtils.mkdir_p(path) unless File.exists?(path)
+          FileUtils.mkdir_p(path) unless File.exist?(path)
         end
       end
 

--- a/sunspot_solr/spec/server_spec.rb
+++ b/sunspot_solr/spec/server_spec.rb
@@ -1,3 +1,4 @@
+
 require File.expand_path('spec_helper', File.dirname(__FILE__))
 require 'tempfile'
 
@@ -11,88 +12,90 @@ describe Sunspot::Solr::Server do
   end
 
   it 'runs server in current process' do
-    @server.should_not_receive(:fork)
-    @server.should_receive(:exec).with(/java .*-jar start.jar/)
+    expect(@server).not_to receive(:fork)
+    expect(@server).to receive(:exec).with(/java .*-jar start.jar/)
     @server.run
   end
 
   it 'runs Java with min memory' do
     @server.min_memory = 1024
-    @server.should_receive(:exec).with(/-Xms1024/)
+    expect(@server).to receive(:exec).with(/-Xms1024/)
     @server.run
   end
 
   it 'runs Java with max memory' do
     @server.max_memory = 2048
-    @server.should_receive(:exec).with(/-Xmx2048/)
+    expect(@server).to receive(:exec).with(/-Xmx2048/)
     @server.run
   end
 
   it 'runs Jetty with specified port' do
     @server.port = 8981
-    @server.should_receive(:exec).with(/-Djetty\.port=8981/)
+    expect(@server).to receive(:exec).with(/-Djetty\.port=8981/)
     @server.run
   end
 
   it 'runs Solr with specified data dir' do
     @server.solr_data_dir = '/tmp/var/solr/data'
-    @server.should_receive(:exec).with(%r(-Dsolr\.data\.dir=/tmp/var/solr/data))
+    expect(@server).to receive(:exec).with(%r(-Dsolr\.data\.dir=/tmp/var/solr/data))
     @server.run
   end
 
   it 'runs Solr with specified Solr home' do
     @server.solr_home = '/tmp/var/solr'
-    @server.should_receive(:exec).with(%r(-Dsolr\.solr\.home=/tmp/var/solr))
+    expect(@server).to receive(:exec).with(%r(-Dsolr\.solr\.home=/tmp/var/solr))
     @server.run
   end
 
   it 'runs Solr with specified Solr jar' do
     @server.solr_jar = SUNSPOT_START_JAR
-    FileUtils.should_receive(:cd).with(File.dirname(SUNSPOT_START_JAR))
+    expect(FileUtils).to receive(:cd).with(File.dirname(SUNSPOT_START_JAR))
     @server.run
   end
 
   it 'raises an error if java is missing' do
-    Sunspot::Solr::Java.stub(:installed? => false)
+    allow(Sunspot::Solr::Java).to receive(:installed?).and_return(false)
     expect {
-     Sunspot::Solr::Server.new
+      Sunspot::Solr::Server.new
     }.to raise_error(Sunspot::Solr::Server::JavaMissing)
   end
-
+  
   describe 'with logging' do
     before :each do
       @server.log_level = 'info'
       @server.log_file = 'log/sunspot-development.log'
-      Tempfile.should_receive(:new).with('logging.properties').and_return(@tempfile = StringIO.new)
-      @tempfile.should_receive(:flush)
-      @tempfile.should_receive(:close)
-      @tempfile.stub(:path).and_return('/tmp/logging.properties.12345')
-      @server.stub(:exec)
+      expect(Tempfile).to receive(:new).with('logging.properties').and_return(@tempfile = StringIO.new)
+      expect(@tempfile).to receive(:flush)
+      expect(@tempfile).to receive(:close)
+      
+      # Replace `stub` with `allow`
+      allow(@tempfile).to receive(:path).and_return('/tmp/logging.properties.12345')
+      allow(@server).to receive(:exec)
     end
-
+  
     it 'runs Solr with logging properties file' do
-      @server.should_receive(:exec).with(%r(-Djava\.util\.logging\.config\.file=/tmp/logging\.properties\.12345))
+      expect(@server).to receive(:exec).with(%r(-Djava\.util\.logging\.config\.file=/tmp/logging\.properties\.12345))
       @server.run
     end
 
     it 'sets logging level' do
       @server.run
-      @tempfile.string.should =~ /^java\.util\.logging\.FileHandler\.level *= *INFO$/
+      expect(@tempfile.string).to match(/^java\.util\.logging\.FileHandler\.level *= *INFO$/)
     end
 
     it 'sets handler' do
       @server.run
-      @tempfile.string.should =~ /^handlers *= *java.util.logging.FileHandler$/
+      expect(@tempfile.string).to match(/^handlers *= *java.util.logging.FileHandler$/)
     end
 
     it 'sets formatter' do
       @server.run
-      @tempfile.string.should =~ /^java\.util\.logging\.FileHandler\.formatter *= *java\.util\.logging\.SimpleFormatter$/
+      expect(@tempfile.string).to match(/^java\.util\.logging\.FileHandler\.formatter *= *java\.util\.logging\.SimpleFormatter$/)
     end
 
     it 'sets log file' do
       @server.run
-      @tempfile.string.should =~ /^java\.util\.logging\.FileHandler\.pattern *= *log\/sunspot-development\.log$/
+      expect(@tempfile.string).to match(/^java\.util\.logging\.FileHandler\.pattern *= *log\/sunspot-development\.log$/)
     end
   end
 end

--- a/sunspot_solr/spec/server_spec.rb
+++ b/sunspot_solr/spec/server_spec.rb
@@ -1,4 +1,3 @@
-
 require File.expand_path('spec_helper', File.dirname(__FILE__))
 require 'tempfile'
 
@@ -67,8 +66,6 @@ describe Sunspot::Solr::Server do
       expect(Tempfile).to receive(:new).with('logging.properties').and_return(@tempfile = StringIO.new)
       expect(@tempfile).to receive(:flush)
       expect(@tempfile).to receive(:close)
-      
-      # Replace `stub` with `allow`
       allow(@tempfile).to receive(:path).and_return('/tmp/logging.properties.12345')
       allow(@server).to receive(:exec)
     end


### PR DESCRIPTION
I try to run Rspec with ruby version 3.4.1 it suggested the mention changes. please review.
Rspec is pass in my local machine.
![Solr_rspec](https://github.com/user-attachments/assets/348728b7-a9ad-4a1e-a8d2-281a73ff9a44)
